### PR TITLE
Add ruby 3.0.1 support

### DIFF
--- a/bin/ruby_version_test
+++ b/bin/ruby_version_test
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-rubies=("ruby-2.6.6" "ruby-2.7.1" "ruby-2.7.2" "ruby-2.7.3")
+rubies=("ruby-2.6.6" "ruby-2.7.3" "ruby-3.0.1")
 for i in "${rubies[@]}"
 do
   printf "$i..."


### PR DESCRIPTION
Support latest ruby 3. Also remove support
for all but latest stable versions of previous
ruby version. not 2.6.7 is available at time of
writing but there are issues with its installation
on macosx at least.

see https://bugs.ruby-lang.org/issues/17777
for 2.6.7 issue.